### PR TITLE
[Feature]: 5 Scale rotate and delete icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.0.5
+## 1.0.6
 
 CHANGELOG:
 - adjustment of the dots size
+- scale delete/rotate icons
 
 * TODO: export in different formats and colors

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,7 +42,7 @@ class _MyAppState extends State<MyApp> {
             children: [
               Expanded(
                 child: Center(
-                  child: CanvasWidget(controller: controller, backgroundImage: 'assets/images/background.png',),
+                  child: CanvasWidget(controller: controller, backgroundImage: 'assets/images/background.png', iconsSize: 25.0,),
                 ),
               ),
               CustomDraggableItems(controller: controller, items: [

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "1.0.4"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -109,26 +109,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:
@@ -266,10 +266,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   webdriver:
     dependency: transitive
     description:
@@ -280,4 +280,4 @@ packages:
     version: "3.0.3"
 sdks:
   dart: ">=3.3.3 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_advanced_canvas_editor
 description: "The Advanced Canvas Editor is a powerful tool for drawing and editing, perfect for artists, designers, and developers to create, manipulate, and export canvas-based artwork effortlessly."
-version: 1.0.5
+version: 1.0.6
 homepage:
 
 environment:


### PR DESCRIPTION
CHANGELOG:
- scale icons
- separated the icons from the objects, so they no longer overlap and can now be clicked easily.

How to scale icons:
You can easily do that on the Canvas's constructor:
- prop name: **iconsSize:**
```
CanvasWidget(controller: controller, backgroundImage: 'assets/images/background.png', iconsSize: 25.0,)
```

Result:
<img width="1380" alt="Screenshot 2024-10-04 at 0 33 54" src="https://github.com/user-attachments/assets/a2a3ac02-22d2-48e8-a6ad-6949a1dd2332">
